### PR TITLE
fix: replace meta refresh auto-login redirect with HTTP 302

### DIFF
--- a/app/views/hooks/redmine_oidc/_html_head.html.erb
+++ b/app/views/hooks/redmine_oidc/_html_head.html.erb
@@ -2,9 +2,6 @@
 <% settings = Setting.plugin_redmine_oidc || {} %>
 <% local_login = params[:local_login].present? %>
 <% oidc_auto_login_ready = settings['oidc_auto_login'] == '1' && settings['issuer_url'].present? && settings['client_identifier'].present? && settings['client_secret'].present? %>
-<% if controller.controller_name == 'account' && controller.action_name == 'login' && oidc_auto_login_ready && !local_login %>
-  <meta http-equiv="refresh" content="0;url=<%= h(oidc_authorize_path(back_url: params[:back_url])) %>">
-<% end %>
 <% if settings['oidc_primary_login'] == '1' && !local_login %>
   <style>
     body.controller-account.action-login #content {

--- a/init.rb
+++ b/init.rb
@@ -25,3 +25,8 @@ unless User.reflect_on_association(:oidc_user_links)
     has_many :oidc_user_links, dependent: :destroy
   end
 end
+
+Rails.application.config.after_initialize do
+  require_relative 'lib/redmine_oidc/account_controller_patch'
+  AccountController.include(RedmineOidc::AccountControllerPatch)
+end

--- a/lib/redmine_oidc/account_controller_patch.rb
+++ b/lib/redmine_oidc/account_controller_patch.rb
@@ -1,0 +1,24 @@
+module RedmineOidc
+  module AccountControllerPatch
+    def self.included(base)
+      base.prepend(InstanceMethods)
+    end
+
+    module InstanceMethods
+      def login
+        settings = Setting.plugin_redmine_oidc || {}
+        local_login = params[:local_login].present?
+        oidc_auto_login_ready = settings['oidc_auto_login'] == '1' &&
+                                settings['issuer_url'].present? &&
+                                settings['client_identifier'].present? &&
+                                settings['client_secret'].present?
+
+        if request.get? && oidc_auto_login_ready && !local_login && !User.current.logged?
+          redirect_to oidc_authorize_path(back_url: params[:back_url])
+        else
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The auto-login feature was using a meta http-equiv="refresh" tag to redirect users to the OIDC provider. Modern browsers (Firefox, Chrome) block this type of redirect with a user confirmation popup when the page is served over HTTP, degrading the SSO experience.

Replace the client-side meta refresh with a server-side HTTP 302 redirect in AccountController via a prepended module patch. The redirect is only triggered on GET requests to the login action when auto-login is enabled, OIDC is configured, and the user is not already logged in. The local_login parameter bypass is preserved.