### PR TITLE
Fixing callback_url when reverse proxy is used

### DIFF
--- a/app/controllers/oidc_controller.rb
+++ b/app/controllers/oidc_controller.rb
@@ -255,4 +255,21 @@ class OidcController < ApplicationController
     settings = Setting.plugin_redmine_oidc || {}
     settings['oidc_auto_login'] == '1'
   end
+
+  # Default URL options for generating URLs based on host_name and protocol
+  # defined in application settings.
+  def self.default_url_options
+    options = {:protocol => Setting.protocol}
+    if Setting.host_name.to_s =~ /\A(https?\:\/\/)?(.+?)(\:(\d+))?(\/.+)?\z/i
+      host, port, prefix = $2, $4, $5
+      options.merge!(
+        {
+          :host => host, :port => port, :script_name => prefix
+        }
+      )
+    else
+      options[:host] = Setting.host_name
+    end
+    options
+  end
 end


### PR DESCRIPTION
Right now, the `oidc_callback_url` value is computed using the current request context. This causes the `callback_url` to use the internal hostname and port when redmine is served though a reverse proxy.
This fix set the `default_url_options` to inherit from the settings (and make it coherent with the value displayed in the administration view)